### PR TITLE
[log] Use rotatelogs instead of logrotate

### DIFF
--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/filebeat-configmap.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/filebeat-configmap.yaml
@@ -14,7 +14,7 @@ data:
       json.keys_under_root: true
       json.ignore_decoding_error: true
       paths:
-        - /var/log/curielogger/*.log
+        - /var/log/curielogger/*.log*
 
     output.elasticsearch:
       hosts: "${ELASTICSEARCH_URL}"

--- a/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-deployment.yaml
@@ -42,20 +42,6 @@ spec:
           - name: filebeat-configmap
             subPath: template.json
             mountPath: /usr/share/filebeat/template.json
-      - name: logrotate
-        image: blacklabelops/logrotate:1.2
-        env:
-        - name: LOGS_DIRECTORIES
-          value: "/var/log/curielogger"
-        - name: LOGROTATE_INTERVAL
-          value: hourly
-        - name: LOGROTATE_SIZE
-          value: "10M"
-        - name: LOGROTATE_COPIES
-          value: "10"
-        volumeMounts:
-          - name: curielogger
-            mountPath: /var/log/curielogger
 {{- end }}
       - name: curielogger
         env:
@@ -91,7 +77,7 @@ spec:
         {{ end }}
 {{- if eq .Values.global.settings.curiefense_es_forwarder "filebeat" }}
         args:
-          - /bin/curielogger |tee > /var/log/curielogger/curielogger.log
+          - /bin/curielogger |rotatelogs -e -n 20 /var/log/curielogger/curielogger.log 20M
         command:
           - /bin/bash
           - -c


### PR DESCRIPTION
Contains the changes to helm charts from
https://github.com/curiefense/curiefense/pull/351

Signed-off-by: Xavier <xavier@reblaze.com>