### PR TITLE
Add a uiserver ingress template

### DIFF
--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-deployment.yaml
@@ -32,13 +32,6 @@ spec:
           httpGet:
             path: /
             port: uiserver-http
-        volumeMounts:
-{{- if .Values.global.settings.uiserver_enable_tls }}
-        - mountPath: /run/secrets/uisslcrt
-          name: uisslcrt
-        - mountPath: /run/secrets/uisslkey
-          name: uisslkey
-{{- end }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         resources:
           limits:
@@ -49,21 +42,6 @@ spec:
             cpu: {{ .Values.global.requests.cpu.uiserver }}
       restartPolicy: Always
       serviceAccountName: ""
-      volumes:
-{{- if .Values.global.settings.uiserver_enable_tls }}
-      - name: uisslcrt
-        secret:
-          items:
-          - key: uisslcrt
-            path: uisslcrt
-          secretName: uisslcrt
-      - name: uisslkey
-        secret:
-          items:
-          - key: uisslkey
-            path: uisslkey
-          secretName: uisslkey
-{{- end }}
 {{- if .Values.global.tolerations }}
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-ingress.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-ingress.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.global.settings.uiserver_domain }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: uiserver
+  labels:
+    app.kubernetes.io/name: uiserver
+  annotations:
+    {{- range $key, $value := .Values.global.settings.uiserver_ingress_annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.global.settings.uiserver_ingress_class_name | default "" }}
+{{- if .Values.global.settings.uiserver_enable_tls }}
+  tls:
+  - hosts:
+    - {{ .Values.global.settings.uiserver_domain }}
+    secretName: {{ .Values.global.settings.uiserver_domain  | replace "." "-" }}-tls
+{{- end}}
+  rules:
+  - host: {{ .Values.global.settings.uiserver_domain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: uiserver
+          servicePort: http
+{{- end }}

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-service.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-service.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-  - name: "80"
+  - name: http
     port: 80
     targetPort: 80
   selector:

--- a/curiefense-helm/curiefense/values.yaml
+++ b/curiefense-helm/curiefense/values.yaml
@@ -41,6 +41,8 @@ global:
     docker_tag: 'main'
     redis_port: 6379
     uiserver_enable_tls: false
+    uiserver_domain: ""
+    uiserver_annotations: {}
 
   requests:
     cpu:


### PR DESCRIPTION
This adds a uiserver ingress template so that it's possible to create a domain for the uiserver. Support for self-signed
certificates that are directly mounted into the uiserver deployment is being dropped in this commit. Regular deployments
handle certificates through ingresses. Setting TLS in the POD specifically without even having the uiserver exposed is not
as common.

It's true that people could expose the service, a node port, etc. For those cases we will have to come up with a better solution

Signed-off-by: Flavio Percoco <flaper87@gmail.com>