### PR TITLE
Fix envoy filter

### DIFF
--- a/istio-helm/charts/gateways/istio-ingress/templates/curiefense_lua_filter.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/templates/curiefense_lua_filter.yaml
@@ -20,7 +20,7 @@ spec:
         typed_config:
           "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
           inlineCode: |
-            local session = require "lua.session"
+            local session = require "lua.session_envoy"
             function envoy_on_request(handle)
               session.inspect(handle)
             end


### PR DESCRIPTION
session.lua is named session_envoy.lua since
0c88b4308f08f0aa88f96907455dfd7a4aee7fe2

Signed-off-by: Xavier <xavier@reblaze.com>