### PR TITLE
Add label 'app.kubernetes.io/part-of' to k8s resources

### DIFF
--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-service-headless.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-service-headless.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: confserver
+    app.kubernetes.io/part-of: "curiefense"
   name: confserver-hl
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-service.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: confserver
+    app.kubernetes.io/part-of: "curiefense"
   name: confserver
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-statefulset.yaml
@@ -4,6 +4,7 @@ kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/name: confserver
+    app.kubernetes.io/part-of: "curiefense"
   name: confserver
   namespace: {{ .Release.Namespace }}
 spec:
@@ -18,6 +19,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: confserver
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       initContainers:
         - name: bootstrap-deploy

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/curietasker-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/curietasker-deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: curietasker
+    app.kubernetes.io/part-of: "curiefense"
   name: curietasker
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: curietasker
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       containers:
       - name: curietasker

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: uiserver
+    app.kubernetes.io/part-of: "curiefense"
   name: uiserver
   namespace: {{ .Release.Namespace }}
 spec:
@@ -16,6 +17,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: uiserver
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       containers:
       - name: uiserver

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-ingress.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   name: uiserver
   labels:
     app.kubernetes.io/name: uiserver
+    app.kubernetes.io/part-of: "curiefense"
   annotations:
     {{- range $key, $value := .Values.global.settings.uiserver_ingress_annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-service.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: uiserver
+    app.kubernetes.io/part-of: "curiefense"
   name: uiserver
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/grafana-service-headless.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/grafana-service-headless.yaml
@@ -6,6 +6,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: "curiefense"
   name: grafana-hl
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/grafana-service.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/grafana-service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: "curiefense"
   name: grafana
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/grafana-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/grafana-statefulset.yaml
@@ -5,6 +5,7 @@ kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: "curiefense"
   name: grafana
   namespace: {{ .Release.Namespace }}
 spec:
@@ -19,6 +20,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: grafana
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       containers:
       - name: grafana

--- a/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/prometheus-service-headless.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/prometheus-service-headless.yaml
@@ -6,6 +6,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: "curiefense"
   name: prometheus-hl
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/prometheus-service.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/prometheus-service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: "curiefense"
   name: prometheus
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/prometheus-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/prometheus-statefulset.yaml
@@ -5,6 +5,7 @@ kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: "curiefense"
   name: prometheus
   namespace: {{ .Release.Namespace }}
 spec:
@@ -19,6 +20,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: prometheus
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       containers:
       {{ if regexMatch ".*/.*:" .Values.global.images.prometheus }}

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/elasticsearch-service-headless.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/elasticsearch-service-headless.yaml
@@ -6,6 +6,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/part-of: "curiefense"
   name: elasticsearch-hl
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/elasticsearch-service.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/elasticsearch-service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/part-of: "curiefense"
   name: elasticsearch
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/elasticsearch-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/elasticsearch-statefulset.yaml
@@ -6,6 +6,7 @@ kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/part-of: "curiefense"
   name: elasticsearch
   namespace: {{ .Release.Namespace }}
 spec:
@@ -20,6 +21,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: elasticsearch
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       containers:
       - name: elasticsearch

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/filebeat-configmap.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/filebeat-configmap.yaml
@@ -6,6 +6,8 @@ kind: ConfigMap
 metadata:
   name: filebeat-configmap
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 data:
   filebeat.yml: |-
     filebeat.inputs:

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/fluentd-configmap.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/fluentd-configmap.yaml
@@ -6,6 +6,8 @@ kind: ConfigMap
 metadata:
   name: fluentd-configmap
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 data:
   fluent.conf: |-
     <source>

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/fluentd-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/fluentd-deployment.yaml
@@ -6,6 +6,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: fluentd
+    app.kubernetes.io/part-of: "curiefense"
   name: fluentd
   namespace: {{ .Release.Namespace }}
 spec:
@@ -18,6 +19,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: fluentd
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       containers:
       - name: fluentd

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/fluentd-service.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/fluentd-service.yaml
@@ -6,6 +6,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: fluentd
+    app.kubernetes.io/part-of: "curiefense"
   name: fluentd
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/kibana-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/kibana-deployment.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kibana
+    app.kubernetes.io/part-of: "curiefense"
   name: kibana
   namespace: {{ .Release.Namespace }}
 spec:
@@ -17,6 +18,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kibana
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       containers:
       - name: kibana

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/kibana-service.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/kibana-service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: kibana
+    app.kubernetes.io/part-of: "curiefense"
   name: kibana
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-configmap.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-configmap.yaml
@@ -6,6 +6,8 @@ kind: ConfigMap
 metadata:
   name: logstash-configmap
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 data:
   pipelines.yml: |-
     - pipeline.id: input

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
@@ -6,6 +6,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: logstash
+    app.kubernetes.io/part-of: "curiefense"
   name: logstash
   namespace: {{ .Release.Namespace }}
 spec:
@@ -18,6 +19,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: logstash
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       containers:
       - name: logstash

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-service.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-service.yaml
@@ -6,6 +6,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: logstash
+    app.kubernetes.io/part-of: "curiefense"
   name: logstash
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: curielogger
+    app.kubernetes.io/part-of: "curiefense"
   name: curielogger
   namespace: {{ .Release.Namespace }}
 spec:
@@ -15,6 +16,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: curielogger
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       containers:
 {{- if eq .Values.global.settings.curiefense_es_forwarder "filebeat" }}

--- a/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-destination-rule.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-destination-rule.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: curielogger
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   host: curielogger.{{ .Release.Namespace }}.svc.cluster.local
   trafficPolicy:

--- a/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-service.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: curielogger
+    app.kubernetes.io/part-of: "curiefense"
   name: curielogger
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-service-headless.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-service-headless.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: "curiefense"
   name: redis-hl
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-service.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: "curiefense"
   name: redis
   namespace: {{ .Release.Namespace }}
 spec:

--- a/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-statefulset.yaml
@@ -4,6 +4,7 @@ kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: "curiefense"
   name: redis
   namespace: {{ .Release.Namespace }}
 spec:
@@ -18,6 +19,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: redis
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       containers:
       {{ if regexMatch ".*/.*:" .Values.global.images.redis }}

--- a/curiefense-helm/example-uiserver-tls.yaml
+++ b/curiefense-helm/example-uiserver-tls.yaml
@@ -6,6 +6,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: uisslkey
+    app.kubernetes.io/part-of: "curiefense"
   name: uisslkey
   namespace: curiefense
 type: Opaque
@@ -17,6 +18,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/name: uisslcrt
+    app.kubernetes.io/part-of: "curiefense"
   name: uisslcrt
   namespace: curiefense
 type: Opaque

--- a/curiefense-helm/expose-services.yaml
+++ b/curiefense-helm/expose-services.yaml
@@ -6,6 +6,7 @@ kind: Service
 metadata:
   labels:
     app: uiserver-nodeport-http
+    app.kubernetes.io/part-of: "curiefense"
   name: uiserver-nodeport-http
   namespace: curiefense
 spec:
@@ -30,6 +31,7 @@ kind: Service
 metadata:
   labels:
     app: grafana-nodeport
+    app.kubernetes.io/part-of: "curiefense"
   name: grafana-nodeport
   namespace: curiefense
 spec:
@@ -49,6 +51,7 @@ kind: Service
 metadata:
   labels:
     app: confserver-nodeport
+    app.kubernetes.io/part-of: "curiefense"
   name: confserver-nodeport
   namespace: curiefense
 spec:
@@ -68,6 +71,7 @@ kind: Service
 metadata:
   labels:
     app: kibana-nodeport
+    app.kubernetes.io/part-of: "curiefense"
   name: kibana-nodeport
   namespace: curiefense
 spec:
@@ -87,6 +91,7 @@ kind: Service
 metadata:
   labels:
     app: es-nodeport
+    app.kubernetes.io/part-of: "curiefense"
   name: es-nodeport
   namespace: curiefense
 spec:

--- a/echo-server.yaml
+++ b/echo-server.yaml
@@ -4,12 +4,15 @@ metadata:
   name: echoserver
   labels:
     istio-injection: enabled
+    app.kubernetes.io/part-of: "curiefense"
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echoserver
   namespace: echoserver
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   replicas: 1
   selector:
@@ -19,6 +22,7 @@ spec:
     metadata:
       labels:
         app: echoserver
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       containers:
       - image: gcr.io/google_containers/echoserver:1.0
@@ -35,6 +39,7 @@ metadata:
   labels:
     app: echoserver
     service: echoserver
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   ports:
   - port: 8080
@@ -47,6 +52,8 @@ kind: Gateway
 metadata:
   name: echoserver-gateway
   namespace: echoserver
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   selector:
     istio: ingressgateway # use istio default controller
@@ -63,6 +70,8 @@ kind: VirtualService
 metadata:
   name: echoserver
   namespace: echoserver
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   hosts:
   - "*"

--- a/istio-helm/charts/base/crds/crd-all.gen.yaml
+++ b/istio-helm/charts/base/crds/crd-all.gen.yaml
@@ -9,6 +9,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: destinationrules.networking.istio.io
 spec:
   additionalPrinterColumns:
@@ -1190,6 +1191,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: envoyfilters.networking.istio.io
 spec:
   group: networking.istio.io
@@ -1442,6 +1444,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: gateways.networking.istio.io
 spec:
   group: networking.istio.io
@@ -1604,6 +1607,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: serviceentries.networking.istio.io
 spec:
   additionalPrinterColumns:
@@ -1770,6 +1774,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: sidecars.networking.istio.io
 spec:
   group: networking.istio.io
@@ -1921,6 +1926,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: virtualservices.networking.istio.io
 spec:
   additionalPrinterColumns:
@@ -2741,6 +2747,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: workloadentries.networking.istio.io
 spec:
   additionalPrinterColumns:
@@ -2827,6 +2834,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: workloadgroups.networking.istio.io
 spec:
   additionalPrinterColumns:
@@ -3020,6 +3028,7 @@ metadata:
     heritage: Tiller
     istio: security
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: authorizationpolicies.security.istio.io
 spec:
   group: security.istio.io
@@ -3252,6 +3261,7 @@ metadata:
     heritage: Tiller
     istio: security
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: peerauthentications.security.istio.io
 spec:
   additionalPrinterColumns:
@@ -3347,6 +3357,7 @@ metadata:
     heritage: Tiller
     istio: security
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: requestauthentications.security.istio.io
 spec:
   group: security.istio.io

--- a/istio-helm/charts/base/crds/crd-operator.yaml
+++ b/istio-helm/charts/base/crds/crd-operator.yaml
@@ -5,6 +5,7 @@ metadata:
   name: istiooperators.install.istio.io
   labels:
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.revision

--- a/istio-helm/charts/base/files/gen-istio-cluster.yaml
+++ b/istio-helm/charts/base/files/gen-istio-cluster.yaml
@@ -11,6 +11,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: destinationrules.networking.istio.io
 spec:
   additionalPrinterColumns:
@@ -1192,6 +1193,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: envoyfilters.networking.istio.io
 spec:
   group: networking.istio.io
@@ -1444,6 +1446,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: gateways.networking.istio.io
 spec:
   group: networking.istio.io
@@ -1606,6 +1609,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: serviceentries.networking.istio.io
 spec:
   additionalPrinterColumns:
@@ -1772,6 +1776,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: sidecars.networking.istio.io
 spec:
   group: networking.istio.io
@@ -1923,6 +1928,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: virtualservices.networking.istio.io
 spec:
   additionalPrinterColumns:
@@ -2743,6 +2749,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: workloadentries.networking.istio.io
 spec:
   additionalPrinterColumns:
@@ -2829,6 +2836,7 @@ metadata:
     chart: istio
     heritage: Tiller
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: workloadgroups.networking.istio.io
 spec:
   additionalPrinterColumns:
@@ -3022,6 +3030,7 @@ metadata:
     heritage: Tiller
     istio: security
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: authorizationpolicies.security.istio.io
 spec:
   group: security.istio.io
@@ -3254,6 +3263,7 @@ metadata:
     heritage: Tiller
     istio: security
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: peerauthentications.security.istio.io
 spec:
   additionalPrinterColumns:
@@ -3349,6 +3359,7 @@ metadata:
     heritage: Tiller
     istio: security
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
   name: requestauthentications.security.istio.io
 spec:
   group: security.istio.io
@@ -3459,6 +3470,7 @@ metadata:
   name: istiooperators.install.istio.io
   labels:
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.revision
@@ -3529,6 +3541,7 @@ metadata:
   labels:
     app: istio-reader
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 ---
 # Source: base/templates/serviceaccount.yaml
 apiVersion: v1
@@ -3539,6 +3552,7 @@ metadata:
   labels:
     app: istiod
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 ---
 # Source: base/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3548,6 +3562,7 @@ metadata:
   labels:
     app: istiod
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 rules:
   # sidecar injection controller
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -3640,6 +3655,7 @@ metadata:
   labels:
     app: istio-reader
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 rules:
   - apiGroups:
       - "config.istio.io"
@@ -3679,6 +3695,7 @@ metadata:
   labels:
     app: istio-reader
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -3696,6 +3713,7 @@ metadata:
   labels:
     app: istiod
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -3714,6 +3732,7 @@ metadata:
   labels:
     app: istiod
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 rules:
 # permissions to verify the webhook is ready and rejecting
 # invalid config. We use --server-dry-run so no config is persisted.
@@ -3736,6 +3755,7 @@ metadata:
   labels:
     app: istiod
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -3754,6 +3774,7 @@ metadata:
     app: istiod
     release: istio
     istio: istiod
+    app.kubernetes.io/part-of: "curiefense"
 webhooks:
   - name: validation.istio.io
     clientConfig:

--- a/istio-helm/charts/base/templates/clusterrole.yaml
+++ b/istio-helm/charts/base/templates/clusterrole.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: istiod
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 rules:
   # sidecar injection controller
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -111,6 +112,7 @@ metadata:
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 rules:
   - apiGroups:
       - "config.istio.io"

--- a/istio-helm/charts/base/templates/clusterrolebinding.yaml
+++ b/istio-helm/charts/base/templates/clusterrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -21,6 +22,7 @@ metadata:
   labels:
     app: istiod
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/istio-helm/charts/base/templates/endpoints.yaml
+++ b/istio-helm/charts/base/templates/endpoints.yaml
@@ -5,6 +5,8 @@ kind: Endpoints
 metadata:
   name: istiod-remote
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 subsets:
 - addresses:
   - ip: {{ .Values.global.remotePilotAddress }}
@@ -18,6 +20,8 @@ kind: Endpoints
 metadata:
   name: istiod
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 subsets:
 - addresses:
   - ip: {{ .Values.global.remotePilotAddress }}

--- a/istio-helm/charts/base/templates/role.yaml
+++ b/istio-helm/charts/base/templates/role.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: istiod
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 rules:
 # permissions to verify the webhook is ready and rejecting
 # invalid config. We use --server-dry-run so no config is persisted.

--- a/istio-helm/charts/base/templates/rolebinding.yaml
+++ b/istio-helm/charts/base/templates/rolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: istiod
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/istio-helm/charts/base/templates/serviceaccount.yaml
+++ b/istio-helm/charts/base/templates/serviceaccount.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -27,4 +28,5 @@ metadata:
   labels:
     app: istiod
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 ---

--- a/istio-helm/charts/base/templates/services.yaml
+++ b/istio-helm/charts/base/templates/services.yaml
@@ -6,6 +6,8 @@ kind: Service
 metadata:
   name: istiod-remote
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   ports:
   - port: 15012
@@ -19,6 +21,8 @@ kind: Service
 metadata:
   name: istiod
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   ports:
   - port: 15012

--- a/istio-helm/charts/base/templates/validatingwebhookconfiguration.yaml
+++ b/istio-helm/charts/base/templates/validatingwebhookconfiguration.yaml
@@ -7,6 +7,7 @@ metadata:
     app: istiod
     release: {{ .Release.Name }}
     istio: istiod
+    app.kubernetes.io/part-of: "curiefense"
 webhooks:
   - name: validation.istio.io
     clientConfig:

--- a/istio-helm/charts/gateways/istio-ingress/templates/curiefense_access_logs_filter.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/templates/curiefense_access_logs_filter.yaml
@@ -5,6 +5,8 @@ kind: EnvoyFilter
 metadata:
   name: curiefense-access-logs-filter
   namespace: istio-system
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   workloadSelector:
     labels:

--- a/istio-helm/charts/gateways/istio-ingress/templates/curiefense_lua_filter.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/templates/curiefense_lua_filter.yaml
@@ -5,6 +5,8 @@ kind: EnvoyFilter
 metadata:
   name: curiefense-lua-filter
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   workloadSelector:
     labels:

--- a/istio-helm/charts/gateways/istio-ingress/templates/role.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/templates/role.yaml
@@ -9,6 +9,7 @@ metadata:
     istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "IngressGateways"
+    app.kubernetes.io/part-of: "curiefense"
 rules:
 - apiGroups: [""]
   resources: ["secrets"]

--- a/istio-helm/charts/gateways/istio-ingress/templates/rolebindings.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/templates/rolebindings.yaml
@@ -9,6 +9,7 @@ metadata:
     istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "IngressGateways"
+    app.kubernetes.io/part-of: "curiefense"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/istio-helm/charts/gateways/istio-ingress/values.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/values.yaml
@@ -7,6 +7,7 @@ gateways:
     labels:
       app: istio-ingressgateway
       istio: ingressgateway
+      app.kubernetes.io/part-of: "curiefense"
     ports:
     ## You can add custom gateway ports in user values overrides, but it must include those ports since helm replaces.
     # Note that AWS ELB will by default perform health checks on the first port

--- a/istio-helm/charts/istio-cni/templates/clusterrole.yaml
+++ b/istio-helm/charts/istio-cni/templates/clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
     istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
+    app.kubernetes.io/part-of: "curiefense"
 rules:
 - apiGroups: [""]
   resources:
@@ -24,6 +25,7 @@ metadata:
   labels:
     app: istio-cni
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -41,6 +43,7 @@ metadata:
   labels:
     app: istio-cni
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 rules:
   - apiGroups: [""]
     resources: ["pods"]

--- a/istio-helm/charts/istio-cni/templates/clusterrolebinding.yaml
+++ b/istio-helm/charts/istio-cni/templates/clusterrolebinding.yaml
@@ -8,6 +8,7 @@ metadata:
     istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
+    app.kubernetes.io/part-of: "curiefense"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -24,6 +25,7 @@ metadata:
   name: istio-cni-repair-rolebinding
   labels:
     k8s-app: istio-cni-repair
+    app.kubernetes.io/part-of: "curiefense"
 subjects:
 - kind: ServiceAccount
   name: istio-cni
@@ -40,6 +42,7 @@ kind: RoleBinding
 metadata:
   name: istio-cni-psp
   namespace: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: "curiefense"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -57,6 +60,7 @@ metadata:
   name: istio-cni-taint-rolebinding
   labels:
     k8s-app: istio-cni-taint
+    app.kubernetes.io/part-of: "curiefense"
 subjects:
   - kind: ServiceAccount
     name: istio-cni

--- a/istio-helm/charts/istio-cni/templates/configmap-cni.yaml
+++ b/istio-helm/charts/istio-cni/templates/configmap-cni.yaml
@@ -9,6 +9,7 @@ metadata:
     istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
+    app.kubernetes.io/part-of: "curiefense"
 data:
   # The CNI network configuration to add to the plugin chain on each node.  The special
   # values in this config will be automatically populated.
@@ -34,6 +35,7 @@ metadata:
   labels:
     app: istio-cni
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 data:
   config: |
         - name: istio-cni

--- a/istio-helm/charts/istio-cni/templates/daemonset.yaml
+++ b/istio-helm/charts/istio-cni/templates/daemonset.yaml
@@ -12,6 +12,7 @@ metadata:
     istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   selector:
     matchLabels:
@@ -25,6 +26,7 @@ spec:
       labels:
         k8s-app: istio-cni-node
         sidecar.istio.io/inject: "false"
+        app.kubernetes.io/part-of: "curiefense"
       annotations:
         # This, along with the CriticalAddonsOnly toleration below,
         # marks the pod as a critical add-on, ensuring it gets

--- a/istio-helm/charts/istio-cni/templates/serviceaccount.yaml
+++ b/istio-helm/charts/istio-cni/templates/serviceaccount.yaml
@@ -15,3 +15,4 @@ metadata:
     istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Cni"
+    app.kubernetes.io/part-of: "curiefense"

--- a/istio-helm/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -5,6 +5,7 @@ metadata:
     service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
     service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
     istio.io/rev: {{ .Revision | default "default" | quote }}
+    app.kubernetes.io/part-of: "curiefense"
   annotations: {
     {{- if eq (len $containers) 1 }}
     kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/istio-helm/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -12,6 +12,7 @@ metadata:
     operator.istio.io/component: "Pilot"
     release: istio
     istio: pilot
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   minAvailable: 1
   selector:
@@ -30,6 +31,7 @@ metadata:
     install.operator.istio.io/owning-resource: unknown
     operator.istio.io/component: "Pilot"
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 data:
 
   # Configuration file for the mesh networks to be used by the Split Horizon EDS.
@@ -57,6 +59,7 @@ metadata:
     install.operator.istio.io/owning-resource: unknown
     operator.istio.io/component: "Pilot"
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 data:
 
   values: |-
@@ -212,6 +215,7 @@ data:
             service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
             service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
             istio.io/rev: {{ .Revision | default "default" | quote }}
+            app.kubernetes.io/part-of: "curiefense"
           annotations: {
             {{- if eq (len $containers) 1 }}
             kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -703,6 +707,7 @@ data:
             service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
             service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
             istio.io/rev: {{ .Revision | default "default" | quote }}
+            app.kubernetes.io/part-of: "curiefense"
           annotations: {
             {{- if eq (len $containers) 1 }}
             kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -943,6 +948,7 @@ metadata:
     app: istiod
     istio: pilot
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   ports:
     - port: 15010
@@ -977,6 +983,7 @@ metadata:
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   strategy:
     rollingUpdate:
@@ -994,6 +1001,7 @@ spec:
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         istio: pilot
+        app.kubernetes.io/part-of: "curiefense"
       annotations:
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
@@ -1135,6 +1143,7 @@ metadata:
     istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
     operator.istio.io/component: "Pilot"
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   maxReplicas: 5
   minReplicas: 1
@@ -1159,6 +1168,7 @@ metadata:
     istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
     operator.istio.io/component: "Pilot"
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -1251,6 +1261,7 @@ metadata:
   namespace: istio-system
   labels:
     istio.io/rev: default
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -1310,6 +1321,7 @@ metadata:
   namespace: istio-system
   labels:
     istio.io/rev: default
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -1419,6 +1431,7 @@ metadata:
   namespace: istio-system
   labels:
     istio.io/rev: default
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -1523,6 +1536,7 @@ metadata:
     istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
     operator.istio.io/component: "Pilot"
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -1615,6 +1629,7 @@ metadata:
   namespace: istio-system
   labels:
     istio.io/rev: default
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -1674,6 +1689,7 @@ metadata:
   namespace: istio-system
   labels:
     istio.io/rev: default
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -1813,6 +1829,7 @@ metadata:
   namespace: istio-system
   labels:
     istio.io/rev: default
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -1947,6 +1964,7 @@ metadata:
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: istio
+    app.kubernetes.io/part-of: "curiefense"
 webhooks:
 - name: sidecar-injector.istio.io
   clientConfig:

--- a/istio-helm/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -6,6 +6,7 @@ metadata:
     service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
     service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
     istio.io/rev: {{ .Revision | default "default" | quote }}
+    app.kubernetes.io/part-of: "curiefense"
   annotations: {
     {{- if eq (len $containers) 1 }}
     kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/istio-helm/charts/istio-control/istio-discovery/templates/autoscale.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/templates/autoscale.yaml
@@ -10,6 +10,7 @@ metadata:
     istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   maxReplicas: {{ .Values.pilot.autoscaleMax }}
   minReplicas: {{ .Values.pilot.autoscaleMin }}

--- a/istio-helm/charts/istio-control/istio-discovery/templates/configmap-jwks.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/templates/configmap-jwks.yaml
@@ -9,6 +9,7 @@ metadata:
     istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
+    app.kubernetes.io/part-of: "curiefense"
 data:
   extra.pem: {{ .Values.pilot.jwksResolverExtraRootCA | quote }}
 {{- end }}

--- a/istio-helm/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -80,6 +80,7 @@ metadata:
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 data:
 
   # Configuration file for the mesh networks to be used by the Split Horizon EDS.

--- a/istio-helm/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     operator.istio.io/component: "Pilot"
     istio: pilot
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 {{- range $key, $val := .Values.pilot.deploymentLabels }}
     {{ $key }}: "{{ $val }}"
 {{- end }}
@@ -39,6 +40,7 @@ spec:
         install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
+        app.kubernetes.io/part-of: "curiefense"
         {{- if eq .Values.revision ""}}
         istio: pilot
         {{- else }}

--- a/istio-helm/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -9,6 +9,7 @@ metadata:
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 data:
 {{/* Scope the values to just top level fields used in the template, to reduce the size. */}}
   values: |-

--- a/istio-helm/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -38,6 +38,7 @@ metadata:
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 webhooks:
 {{- if .Values.sidecarInjectorWebhook.useLegacySelectors}}
 {{- /* Setup the "legacy" selectors. These are for backwards compatibility, will be removed in the future. */}}

--- a/istio-helm/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/templates/poddisruptionbudget.yaml
@@ -11,6 +11,7 @@ metadata:
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
     istio: pilot
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   minAvailable: 1
   selector:

--- a/istio-helm/charts/istio-control/istio-discovery/templates/service.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/templates/service.yaml
@@ -10,6 +10,7 @@ metadata:
     app: istiod
     istio: pilot
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   ports:
     - port: 15010

--- a/istio-helm/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
@@ -13,6 +13,7 @@ metadata:
     istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -132,6 +133,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -195,6 +197,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -372,6 +375,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -544,6 +548,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
@@ -662,6 +667,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
@@ -775,6 +781,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER

--- a/istio-helm/charts/istio-control/istio-discovery/templates/telemetryv2_1.9.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/templates/telemetryv2_1.9.yaml
@@ -13,6 +13,7 @@ metadata:
     istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -132,6 +133,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -195,6 +197,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -373,6 +376,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -545,6 +549,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
@@ -663,6 +668,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
@@ -776,6 +782,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER

--- a/istio-helm/charts/istio-operator/crds/crd-operator.yaml
+++ b/istio-helm/charts/istio-operator/crds/crd-operator.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: istiooperators.install.istio.io
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   group: install.istio.io
   names:

--- a/istio-helm/charts/istio-operator/files/gen-operator.yaml
+++ b/istio-helm/charts/istio-operator/files/gen-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     istio-operator-managed: Reconcile
     istio-injection: disabled
+    app.kubernetes.io/part-of: "curiefense"
 ---
 # Source: istio-operator/templates/service_account.yaml
 apiVersion: v1
@@ -14,6 +15,8 @@ kind: ServiceAccount
 metadata:
   namespace: istio-operator
   name: istio-operator
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 ---
 # Source: istio-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -21,6 +24,8 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: istio-operator
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 rules:
 # istio groups
 - apiGroups:
@@ -136,6 +141,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: istio-operator
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 subjects:
 - kind: ServiceAccount
   name: istio-operator
@@ -152,6 +159,7 @@ metadata:
   namespace: istio-operator
   labels:
     name: istio-operator
+    app.kubernetes.io/part-of: "curiefense"
   name: istio-operator
 spec:
   ports:
@@ -168,6 +176,8 @@ kind: Deployment
 metadata:
   namespace: istio-operator
   name: istio-operator
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   replicas: 1
   selector:
@@ -177,6 +187,7 @@ spec:
     metadata:
       labels:
         name: istio-operator
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       serviceAccountName: istio-operator
       containers:

--- a/istio-helm/charts/istio-operator/templates/clusterrole.yaml
+++ b/istio-helm/charts/istio-operator/templates/clusterrole.yaml
@@ -3,6 +3,8 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 rules:
 # istio groups
 - apiGroups:

--- a/istio-helm/charts/istio-operator/templates/clusterrole_binding.yaml
+++ b/istio-helm/charts/istio-operator/templates/clusterrole_binding.yaml
@@ -2,6 +2,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 subjects:
 - kind: ServiceAccount
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}

--- a/istio-helm/charts/istio-operator/templates/deployment.yaml
+++ b/istio-helm/charts/istio-operator/templates/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   namespace: {{.Values.operatorNamespace}}
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   replicas: 1
   selector:
@@ -12,6 +14,7 @@ spec:
     metadata:
       labels:
         name: istio-operator
+        app.kubernetes.io/part-of: "curiefense"
     spec:
       serviceAccountName: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
       containers:

--- a/istio-helm/charts/istio-operator/templates/namespace.yaml
+++ b/istio-helm/charts/istio-operator/templates/namespace.yaml
@@ -5,4 +5,5 @@ metadata:
   labels:
     istio-operator-managed: Reconcile
     istio-injection: disabled
+    app.kubernetes.io/part-of: "curiefense"
 ---

--- a/istio-helm/charts/istio-operator/templates/service.yaml
+++ b/istio-helm/charts/istio-operator/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   namespace: {{.Values.operatorNamespace}}
   labels:
     name: istio-operator
+    app.kubernetes.io/part-of: "curiefense"
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
 spec:
   ports:

--- a/istio-helm/charts/istio-operator/templates/service_account.yaml
+++ b/istio-helm/charts/istio-operator/templates/service_account.yaml
@@ -3,6 +3,8 @@ kind: ServiceAccount
 metadata:
   namespace: {{.Values.operatorNamespace}}
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  labels:
+    app.kubernetes.io/part-of: "curiefense"
 {{- if .Values.imagePullSecrets }}
 imagePullSecrets:
 {{- range .Values.imagePullSecrets }}

--- a/istio-helm/charts/istiod-remote/files/gateway-injection-template.yaml
+++ b/istio-helm/charts/istiod-remote/files/gateway-injection-template.yaml
@@ -5,6 +5,7 @@ metadata:
     service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
     service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
     istio.io/rev: {{ .Revision | default "default" | quote }}
+    app.kubernetes.io/part-of: "curiefense"
   annotations: {
     {{- if eq (len $containers) 1 }}
     kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/istio-helm/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/istio-helm/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -10,6 +10,7 @@ metadata:
     install.operator.istio.io/owning-resource: unknown
     operator.istio.io/component: "Pilot"
     release: istiod-remote
+    app.kubernetes.io/part-of: "curiefense"
 data:
 
   # Configuration file for the mesh networks to be used by the Split Horizon EDS.
@@ -37,6 +38,7 @@ metadata:
     install.operator.istio.io/owning-resource: unknown
     operator.istio.io/component: "Pilot"
     release: istiod-remote
+    app.kubernetes.io/part-of: "curiefense"
 data:
 
   values: |-
@@ -192,6 +194,7 @@ data:
             service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
             service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
             istio.io/rev: {{ .Revision | default "default" | quote }}
+            app.kubernetes.io/part-of: "curiefense"
           annotations: {
             {{- if eq (len $containers) 1 }}
             kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -683,6 +686,7 @@ data:
             service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
             service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
             istio.io/rev: {{ .Revision | default "default" | quote }}
+            app.kubernetes.io/part-of: "curiefense"
           annotations: {
             {{- if eq (len $containers) 1 }}
             kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
@@ -921,6 +925,7 @@ metadata:
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: istiod-remote
+    app.kubernetes.io/part-of: "curiefense"
 webhooks:
 - name: sidecar-injector.istio.io
   clientConfig:

--- a/istio-helm/charts/istiod-remote/files/injection-template.yaml
+++ b/istio-helm/charts/istiod-remote/files/injection-template.yaml
@@ -6,6 +6,7 @@ metadata:
     service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name  | quote }}
     service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest"  | quote }}
     istio.io/rev: {{ .Revision | default "default" | quote }}
+    app.kubernetes.io/part-of: "curiefense"
   annotations: {
     {{- if eq (len $containers) 1 }}
     kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",

--- a/istio-helm/charts/istiod-remote/templates/configmap.yaml
+++ b/istio-helm/charts/istiod-remote/templates/configmap.yaml
@@ -80,6 +80,7 @@ metadata:
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 data:
 
   # Configuration file for the mesh networks to be used by the Split Horizon EDS.

--- a/istio-helm/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/istio-helm/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -9,6 +9,7 @@ metadata:
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 data:
 {{/* Scope the values to just top level fields used in the template, to reduce the size. */}}
   values: |-

--- a/istio-helm/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/istio-helm/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -38,6 +38,7 @@ metadata:
     operator.istio.io/component: "Pilot"
     app: sidecar-injector
     release: {{ .Release.Name }}
+    app.kubernetes.io/part-of: "curiefense"
 webhooks:
 {{- if .Values.sidecarInjectorWebhook.useLegacySelectors}}
 {{- /* Setup the "legacy" selectors. These are for backwards compatibility, will be removed in the future. */}}

--- a/istio-helm/charts/istiod-remote/templates/telemetryv2_1.8.yaml
+++ b/istio-helm/charts/istiod-remote/templates/telemetryv2_1.8.yaml
@@ -13,6 +13,7 @@ metadata:
     istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -132,6 +133,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -195,6 +197,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -372,6 +375,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -544,6 +548,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
@@ -662,6 +667,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
@@ -775,6 +781,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER

--- a/istio-helm/charts/istiod-remote/templates/telemetryv2_1.9.yaml
+++ b/istio-helm/charts/istiod-remote/templates/telemetryv2_1.9.yaml
@@ -13,6 +13,7 @@ metadata:
     istio.io/rev: {{ .Values.revision | default "default" }}
     install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
     operator.istio.io/component: "Pilot"
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -132,6 +133,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -195,6 +197,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER
@@ -373,6 +376,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: NETWORK_FILTER
@@ -545,6 +549,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
 {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
@@ -663,6 +668,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
   {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
@@ -776,6 +782,7 @@ metadata:
   {{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
+    app.kubernetes.io/part-of: "curiefense"
 spec:
   configPatches:
     - applyTo: HTTP_FILTER


### PR DESCRIPTION
This label makes it possible to aggregate all curiefense resources from
an Application (cf. https://github.com/kubernetes-sigs/application)

Signed-off-by: Xavier <xavier@reblaze.com>