### PR TITLE
Allow to disable Istio CRs

### DIFF
--- a/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-destination-rule.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-destination-rule.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.global.proxy.frontend "istio" }}
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -10,3 +11,4 @@ spec:
   trafficPolicy:
     tls:
       mode: DISABLE
+{{- end }}

--- a/curiefense-helm/curiefense/values.yaml
+++ b/curiefense-helm/curiefense/values.yaml
@@ -1,5 +1,10 @@
 global:
   imagePullPolicy: Always
+
+  proxy:
+    # Frontend proxy used in the cluster: istio, nginx, etc.
+    frontend: "istio"
+
   images:
     confserver: curiefense/confserver
     curielogger: curiefense/curielogger


### PR DESCRIPTION
This will allow to skip installing Istio CRs in clusters where Istio has not
been deployed. For example, when using nginx as the frontend

Signed-off-by: Flavio Percoco <flaper87@gmail.com>