### PR TITLE
Add support for minio as cloud storage backend

### DIFF
--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-statefulset.yaml
@@ -52,6 +52,14 @@ spec:
           value: "yes"
         - name: CURIE_BUCKET_LINK
           value: {{ .Values.global.settings.curieconf_manifest_url }}
+{{- if eq .Values.global.settings.curiefense_bucket_type "minio" }}
+        - name: CURIE_MINIO_HOST
+          value: {{ .Values.global.settings.curiefense_minio_host }}
+{{- if .Values.global.settings.curiefense_minio_insecure }}
+        - name: CURIE_MINIO_SECURE
+          value: "FALSE"
+{{- end }}
+{{- end }}
         {{ if regexMatch ".*/.*:" .Values.global.images.confserver }}
         {{/* The image name contains a version tag (e.g. for tests), do not append docker_tag */}}
         image: {{ .Values.global.images.confserver }}
@@ -81,6 +89,14 @@ spec:
         env:
         - name: CURIE_BUCKET_LINK
           value: {{ .Values.global.settings.curieconf_manifest_url }}
+{{- if eq .Values.global.settings.curiefense_bucket_type "minio" }}
+        - name: CURIE_MINIO_HOST
+          value: {{ .Values.global.settings.curiefense_minio_host }}
+{{- if .Values.global.settings.curiefense_minio_insecure }}
+        - name: CURIE_MINIO_SECURE
+          value: "FALSE"
+{{- end }}
+{{- end }}
         {{ if regexMatch ".*/.*:" .Values.global.images.confserver }}
         {{/* The image name contains a version tag (e.g. for tests), do not append docker_tag */}}
         image: {{ .Values.global.images.confserver }}
@@ -101,6 +117,10 @@ spec:
 {{- if eq .Values.global.settings.curiefense_bucket_type "local-bucket" }}
         - mountPath: /bucket
           name: local-bucket
+{{- end }}
+{{- if eq .Values.global.settings.curiefense_bucket_type "minio" }}
+        - mountPath: /run/secrets/miniocfg
+          name: miniocfg
 {{- end }}
         - mountPath: /config
           name: persistent-confdb
@@ -139,6 +159,14 @@ spec:
         hostPath:
           path: /bucket
           type: DirectoryOrCreate
+{{- end }}
+{{- if eq .Values.global.settings.curiefense_bucket_type "minio" }}
+      - name: miniocfg
+        secret:
+          items:
+          - key: miniocfg
+            path: miniocfg
+          secretName: miniocfg
 {{- end }}
       - name: uwsgi-socket
         emptyDir: {}

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/minio-service.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/minio-service.yaml
@@ -1,0 +1,23 @@
+{{- if eq .Values.global.settings.curiefense_bucket_type "minio" }}
+{{- if .Values.global.enable.minio }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/part-of: "curiefense"
+  name: minio
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: "minio-api"
+    port: 9000
+    targetPort: 9000
+  - name: "minio-gui"
+    port: 9001
+    targetPort: 9001
+  selector:
+    app.kubernetes.io/name: minio
+{{- end }}
+{{- end }}

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/minio-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/minio-statefulset.yaml
@@ -1,0 +1,96 @@
+{{- if eq .Values.global.settings.curiefense_bucket_type "minio" }}
+{{- if .Values.global.enable.minio }}
+---
+# Simple minio server, for testing purposes.
+# admin user & password are default: do not expose this service
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/part-of: "curiefense"
+  name: minio
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  serviceName: minio-hl
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+        app.kubernetes.io/part-of: "curiefense"
+    spec:
+      initContainers:
+        - name: minio-init
+          image: {{ .Values.global.images.minio }}
+          volumeMounts:
+          - mountPath: /data
+            name: persistent-minio
+          - mountPath: /run/secrets/miniocfg
+            name: miniocfg
+          command:
+            - /bin/bash
+            - -c
+            - --
+          args:
+            - mkdir -p /data/curiefense-minio-bucket
+            # attempt to create a non-default service account -- does not work yet
+            # - mkdir -p /data/.minio.sys/config/iam/service-accounts/$(grep '^access_key' /var/run/secrets/miniocfg/miniocfg|cut -c14-)/; mkdir -p /data/curiefense-minio-bucket; echo "{\"version\":1,\"credentials\":{\"accessKey\":\"ACCESSKEY\",\"secretKey\":\"SECRETKEY\",\"expiration\":\"1970-01-01T00:00:00Z\",\"status\":\"on\",\"parentUser\":\"minioadmin\"}}" | sed -e "s/ACCESSKEY/$(grep '^access_key' /var/run/secrets/miniocfg/miniocfg|cut -c14-)/" -e "s/SECRETKEY/$(grep '^secret_key' /var/run/secrets/miniocfg/miniocfg|cut -c14-)/" > /data/.minio.sys/config/iam/service-accounts/$(grep '^access_key' /var/run/secrets/miniocfg/miniocfg|cut -c14-)/identity.json
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          resources:
+            limits:
+              memory: "500Mi"
+              cpu: "1"
+            requests:
+              memory: "100Mi"
+              cpu: {{ .Values.global.requests.cpu.minio_init }}
+      containers:
+      - name: minio
+        env:
+        image: {{ .Values.global.images.minio }}
+        volumeMounts:
+        - mountPath: /data
+          name: persistent-minio
+        - mountPath: /run/secrets/miniocfg
+          name: miniocfg
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        resources:
+          limits:
+            memory: "500Mi"
+            cpu: "500m"
+          requests:
+            memory: "100Mi"
+            cpu: {{ .Values.global.requests.cpu.minio }}
+        command: ["minio", "server", "/data/", "--console-address", ":9001"]
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes:
+      - name: miniocfg
+        secret:
+          items:
+          - key: miniocfg
+            path: miniocfg
+          secretName: miniocfg
+      - name: uwsgi-socket
+        emptyDir: {}
+{{- if .Values.global.tolerations }}
+      tolerations:
+{{ toYaml .Values.global.tolerations | indent 8 }}
+{{- end }}
+  volumeClaimTemplates:
+  - metadata:
+      name: persistent-minio
+    spec:
+      storageClassName: {{ .Values.global.storage.storage_class_name }}
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.global.storage.minio_storage_size }}
+{{- end }}
+{{- end }}

--- a/curiefense-helm/curiefense/use-minio.yaml
+++ b/curiefense-helm/curiefense/use-minio.yaml
@@ -1,0 +1,7 @@
+---
+# use this file to override default values from ../values.yaml
+# ./deploy.sh -f curiefense/use-minio.yaml
+global:
+  settings:
+    curieconf_manifest_url: 'minio://curiefense-minio-bucket/prod/manifest.json'
+    curiefense_bucket_type: 'minio'

--- a/curiefense-helm/curiefense/values.yaml
+++ b/curiefense-helm/curiefense/values.yaml
@@ -13,10 +13,10 @@ global:
     curietasker: curiefense/curietasker
     redis: curiefense/redis
     uiserver: curiefense/uiserver
-    curiesync: curiefense/curiesync
     grafana: curiefense/grafana
     prometheus: curiefense/prometheus
     fluentd: curiefense/fluentd
+    minio: minio/minio:RELEASE.2021-10-13T00-23-17Z
 
   storage:
     # use the default storage class if null
@@ -26,6 +26,7 @@ global:
     elasticsearch_storage_size: '10Gi'
     prometheus_storage_size: '1Gi'
     redis_storage_size: '1Gi'
+    minio_storage_size: '1Gi'
 
   settings:
     curiefense_metrics_prometheus_enabled: true
@@ -41,8 +42,12 @@ global:
     curiefense_fluentd_url: 'http://fluentd:5001/'
     # change curiefense_kibana_url if you supply your own kibana server.
     curiefense_kibana_url: 'http://kibana:5601/'
-    # supported types: 's3', 'gs', 'local-bucket'
+    # supported types: 's3', 'gs', 'local-bucket', 'minio'
     curiefense_bucket_type: 's3'
+    # minio hostname and port, when curiefense_bucket_type is minio
+    curiefense_minio_host: 'minio:9000'
+    # set to true to disable TLS for minio, for testing environments
+    curiefense_minio_insecure: false
     curiefense_es_index_name: 'curieaccesslog'
     # docker_tag will be overridden by deploy.sh
     docker_tag: 'main'
@@ -65,6 +70,8 @@ global:
       prometheus: "100m"
       grafana: "20m"
       elasticsearch: "1"
+      minio_init: "100m"
+      minio: "200m"
 
   enable:
     # set to false to disable parts of this deployment, ex. if you prefer to use your own versions
@@ -75,8 +82,4 @@ global:
     fluentd: true
     logstash: true
     filebeat: true
-
-  curielogger:
-    extraEnv: []
-    extraVolumes: []
-    extraVolumeMounts: []
+    minio: true

--- a/curiefense-helm/example-miniocfg.yaml
+++ b/curiefense-helm/example-miniocfg.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Secret
+data:
+  miniocfg: "W2RlZmF1bHRdCmFjY2Vzc19rZXkgPSBtaW5pb2FkbWluCnNlY3JldF9rZXkgPSBtaW5pb2FkbWluCg=="
+metadata:
+  labels:
+    app.kubernetes.io/name: miniocfg
+  name: miniocfg
+  namespace: curiefense
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+data:
+  miniocfg: "W2RlZmF1bHRdCmFjY2Vzc19rZXkgPSBtaW5pb2FkbWluCnNlY3JldF9rZXkgPSBtaW5pb2FkbWluCg=="
+metadata:
+  labels:
+    app.kubernetes.io/name: miniocfg
+  name: miniocfg
+  namespace: istio-system
+type: Opaque

--- a/istio-helm/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -105,6 +105,14 @@ spec:
           env:
             - name: CURIE_BUCKET_LINK
               value: "{{ $.Values.global.proxy.curieconf_manifest_url }}"
+{{- if eq $.Values.global.proxy.curiefense_bucket_type "minio" }}
+            - name: CURIE_MINIO_HOST
+              value: "{{ $.Values.global.proxy.curiefense_minio_host }}"
+{{- if $.Values.global.proxy.curiefense_minio_insecure }}
+            - name: CURIE_MINIO_SECURE
+              value: "FALSE"
+{{- end }}
+{{- end }}
             - name: CURIESYNC_QUIET
               value: "true"
             - name: RUN_MODE
@@ -134,6 +142,10 @@ spec:
           - mountPath: /bucket
             name: local-bucket
 {{- end }}
+{{- if eq $.Values.global.proxy.curiefense_bucket_type "minio" }}
+          - mountPath: /run/secrets/miniocfg
+            name: miniocfg
+{{- end }}
           - mountPath: /config
             name: curiefense-config
 {{- end }}
@@ -148,6 +160,14 @@ spec:
           env:
             - name: CURIE_BUCKET_LINK
               value: {{ $.Values.global.proxy.curieconf_manifest_url }}
+{{- if eq $.Values.global.proxy.curiefense_bucket_type "minio" }}
+            - name: CURIE_MINIO_HOST
+              value: "{{ $.Values.global.proxy.curiefense_minio_host }}"
+{{- if $.Values.global.proxy.curiefense_minio_insecure }}
+            - name: CURIE_MINIO_SECURE
+              value: "FALSE"
+{{- end }}
+{{- end }}
             - name: CURIESYNC_QUIET
               value: "true"
             - name: RUN_MODE
@@ -172,6 +192,10 @@ spec:
 {{- if eq $.Values.global.proxy.curiefense_bucket_type "local-bucket" }}
           - mountPath: /bucket
             name: local-bucket
+{{- end }}
+{{- if eq $.Values.global.proxy.curiefense_bucket_type "minio" }}
+          - mountPath: /run/secrets/miniocfg
+            name: miniocfg
 {{- end }}
           - mountPath: /config
             name: curiefense-config
@@ -410,6 +434,14 @@ spec:
         hostPath:
           path: /bucket
           type: DirectoryOrCreate
+{{- end }}
+{{- if eq $.Values.global.proxy.curiefense_bucket_type "minio" }}
+      - name: miniocfg
+        secret:
+          items:
+          - key: miniocfg
+            path: miniocfg
+          secretName: miniocfg
 {{- end }}
       - name: curiefense-config
         emptyDir: {}

--- a/istio-helm/charts/gateways/istio-ingress/values.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/values.yaml
@@ -238,8 +238,12 @@ global:
     gw_image: curiefense/curieproxy-istio
     curiesync_image: curiefense/curiesync
     curieconf_manifest_url: "s3://curiefense-test01/prod/manifest.json"
-    # allowed values: "s3", "gs", "local-bucket"
+    # allowed values: "s3", "gs", "local-bucket", "minio"
     curiefense_bucket_type: "s3"
+    # minio hostname and port, when curiefense_bucket_type is minio
+    curiefense_minio_host: "minio.curiefense:9000"
+    # set to true to disable TLS for minio, for testing environments
+    curiefense_minio_insecure: false
     # namespace where curiefense components are running (redis, curielogger)
     curiefense_namespace: "curiefense"
     # typically "redis.$curiefense_namespace", can be changed to use an external redis instance

--- a/istio-helm/charts/use-gs.yaml
+++ b/istio-helm/charts/use-gs.yaml
@@ -1,8 +1,0 @@
----
-# use this file to override default values from ../values.yaml
-# ./deploy.sh -f chart/use-gs.yaml
-global:
-  proxy:
-    curieconf_manifest_url: "gs://curiefense-test-s3-replacement/prod/manifest.json"
-    curiefense_bucket_type: "gs"
-

--- a/istio-helm/use-minio.yaml
+++ b/istio-helm/use-minio.yaml
@@ -1,0 +1,8 @@
+---
+# use this file to override default values from ../values.yaml
+# ./deploy.sh -f use-minio.yaml
+global:
+  proxy:
+    curieconf_manifest_url: 'minio://curiefense-minio-bucket/prod/manifest.json'
+    curiefense_bucket_type: 'minio'
+


### PR DESCRIPTION
Minio can be used instead of S3 or GS buckets.

Example credentials are provided in curiefense-helm/example-miniocfg.yaml

A simple, single-node minio server is included for convenience. Its
deployment can be disabled by setting global.enable.minio to false.

Signed-off-by: Xavier <xavier@reblaze.com>