### PR TITLE
Make istio components deployment namespace configurable

### DIFF
--- a/curiefense-helm/deploy.sh
+++ b/curiefense-helm/deploy.sh
@@ -9,6 +9,7 @@ if [ -z "$DOCKER_TAG" ]; then
     DOCKER_TAG="$GITTAG-$DOCKER_DIR_HASH"
 fi
 
+NAMESPACE=${NAMESPACE:-curiefense}
 PARAMS=()
 
 if [ -n "$NOPULL" ]; then
@@ -23,13 +24,13 @@ else
 fi
 
 # shellcheck disable=SC2086
-if ! helm upgrade --install --namespace curiefense --reuse-values \
+if ! helm upgrade --install --namespace "$NAMESPACE" --reuse-values \
     --set "global.settings.docker_tag=$DOCKER_TAG" \
     --wait --timeout 600s --create-namespace \
     "${PARAMS[@]}" "$@" curiefense curiefense/
 then
     echo "curiefense deployment failure... "
-    kubectl --namespace curiefense describe pods
+    kubectl --namespace "$NAMESPACE" describe pods
 
     # Template generation
     helm template --debug --set "global.settings.docker_tag=$DOCKER_TAG" "${PARAMS[@]}" "$@" curiefense curiefense/

--- a/istio-helm/charts/base/files/gen-istio-cluster.yaml
+++ b/istio-helm/charts/base/files/gen-istio-cluster.yaml
@@ -3537,7 +3537,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-reader-service-account
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: istio
@@ -3548,7 +3548,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istiod-service-account
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app: istiod
     release: istio
@@ -3558,7 +3558,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-istio-system
+  name: istiod-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: istio
@@ -3651,7 +3651,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-istio-system
+  name: istio-reader-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: istio
@@ -3691,7 +3691,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-istio-system
+  name: istio-reader-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: istio
@@ -3699,17 +3699,17 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-istio-system
+  name: istio-reader-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istio-reader-service-account
-    namespace: istio-system
+    namespace: {{ .Release.Namespace }}
 ---
 # Source: base/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-istio-system
+  name: istiod-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: istio
@@ -3717,18 +3717,18 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-istio-system
+  name: istiod-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istiod-service-account
-    namespace: istio-system
+    namespace: {{ .Release.Namespace }}
 ---
 # Source: base/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: istiod-istio-system
-  namespace: istio-system
+  name: istiod-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: istiod
     release: istio
@@ -3750,8 +3750,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: istiod-istio-system
-  namespace: istio-system
+  name: istiod-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: istiod
     release: istio
@@ -3759,17 +3759,17 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: istiod-istio-system
+  name: istiod-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istiod-service-account
-    namespace: istio-system
+    namespace: {{ .Release.Namespace }}
 ---
 # Source: base/templates/validatingwebhookconfiguration.yaml
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istiod-istio-system
+  name: "istiod-{{ .Release.Namespace }}"
   labels:
     app: istiod
     release: istio
@@ -3780,7 +3780,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: istio-system
+        namespace: "{{ .Release.Namespace }}"
         path: "/validate"
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:

--- a/istio-helm/charts/base/templates/clusterrole.yaml
+++ b/istio-helm/charts/base/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -108,7 +108,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}

--- a/istio-helm/charts/base/templates/clusterrolebinding.yaml
+++ b/istio-helm/charts/base/templates/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
@@ -9,16 +9,16 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istio-reader-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -26,9 +26,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istiod-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ .Release.Namespace }}
 ---

--- a/istio-helm/charts/base/templates/role.yaml
+++ b/istio-helm/charts/base/templates/role.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
-  namespace: {{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/istio-helm/charts/base/templates/rolebinding.yaml
+++ b/istio-helm/charts/base/templates/rolebinding.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
-  namespace: {{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -10,8 +10,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istiod-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ .Release.Namespace }}

--- a/istio-helm/charts/base/templates/serviceaccount.yaml
+++ b/istio-helm/charts/base/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ imagePullSecrets:
 {{- end }}
 metadata:
   name: istio-reader-service-account
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
@@ -24,7 +24,7 @@ imagePullSecrets:
   {{- end }}
 metadata:
   name: istiod-service-account
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/istio-helm/charts/base/templates/validatingwebhookconfiguration.yaml
+++ b/istio-helm/charts/base/templates/validatingwebhookconfiguration.yaml
@@ -2,7 +2,7 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -16,7 +16,7 @@ webhooks:
       {{- else }}
       service:
         name: istiod
-        namespace: {{ .Values.global.istioNamespace }}
+        namespace: {{ .Release.Namespace }}
         path: "/validate"
       {{- end }}
       caBundle: "" # patched at runtime when the webhook is ready.

--- a/istio-helm/charts/base/values.yaml
+++ b/istio-helm/charts/base/values.yaml
@@ -6,7 +6,7 @@ global:
   imagePullSecrets: []
 
   # Used to locate istiod.
-  istioNamespace: istio-system
+  istioNamespace: UNUSED1
 
   istiod:
     enableAnalysis: false

--- a/istio-helm/charts/gateways/istio-ingress/templates/curiefense_access_logs_filter.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/templates/curiefense_access_logs_filter.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: curiefense-access-logs-filter
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/part-of: "curiefense"
 spec:

--- a/istio-helm/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -260,7 +260,7 @@ spec:
           {{- if .Values.global.caAddress }}
             value: {{ .Values.global.caAddress }}
           {{- else }}
-            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
           {{- end }}
           - name: NODE_NAME
             valueFrom:

--- a/istio-helm/charts/gateways/istio-ingress/values.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/values.yaml
@@ -259,7 +259,7 @@ global:
   caAddress: ""
 
   # Used to locate istiod.
-  istioNamespace: istio-system
+  istioNamespace: UNUSED2
 
   # Configure the policy for validating JWT.
   # Currently, two options are supported: "third-party-jwt" and "first-party-jwt".

--- a/istio-helm/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
@@ -56,7 +56,7 @@ spec:
     {{- if .Values.global.caAddress }}
       value: {{ .Values.global.caAddress }}
     {{- else }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.namespace }}.svc:15012
     {{- end }}
     - name: POD_NAME
       valueFrom:

--- a/istio-helm/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: istiod
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     app: istiod
     istio.io/rev: default
@@ -25,7 +25,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
@@ -40,12 +40,12 @@ data:
 
   mesh: |-
     defaultConfig:
-      discoveryAddress: istiod.istio-system.svc:15012
+      discoveryAddress: "istiod.{{ .Release.Namespace }}.svc:15012"
       tracing:
         zipkin:
-          address: zipkin.istio-system:9411
+          address: "zipkin.{{ .Release.Namespace }}:9411"
     enablePrometheusMerge: true
-    rootNamespace: istio-system
+    rootNamespace: "{{ .Release.Namespace }}"
     trustDomain: cluster.local
 ---
 # Source: istio-discovery/templates/istiod-injector-configmap.yaml
@@ -53,7 +53,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-sidecar-injector
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
@@ -78,7 +78,7 @@ data:
         "hub": "gcr.io/istio-testing",
         "imagePullPolicy": "",
         "imagePullSecrets": [],
-        "istioNamespace": "istio-system",
+        "istioNamespace": "{{ .Release.Namespace }}",
         "istiod": {
           "enableAnalysis": false
         },
@@ -187,7 +187,8 @@ data:
         "rewriteAppHTTPProbe": true,
         "templates": {},
         "useLegacySelectors": true
-      }
+      },
+      "namespace": "{{ .Release.Namespace }}",
     }
 
   # To disable injection: use omitSidecarInjectorConfigMap, which disables the webhook patching
@@ -429,7 +430,7 @@ data:
             {{- if .Values.global.caAddress }}
               value: {{ .Values.global.caAddress }}
             {{- else }}
-              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
             {{- end }}
             - name: POD_NAME
               valueFrom:
@@ -758,7 +759,7 @@ data:
             {{- if .Values.global.caAddress }}
               value: {{ .Values.global.caAddress }}
             {{- else }}
-              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
             {{- end }}
             - name: POD_NAME
               valueFrom:
@@ -940,7 +941,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istiod
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
@@ -975,7 +976,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istiod
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     app: istiod
     istio.io/rev: default
@@ -1066,7 +1067,7 @@ spec:
           - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
             value: "true"
           - name: ISTIOD_ADDR
-            value: istiod.istio-system.svc:15012
+            value: "istiod.{{ .Release.Namespace }}.svc:15012"
           - name: PILOT_ENABLE_ANALYSIS
             value: "false"
           - name: CLUSTER_ID
@@ -1136,7 +1137,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: istiod
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     app: istiod
     release: istio
@@ -1163,7 +1164,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.8
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
@@ -1258,7 +1259,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.8
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     istio.io/rev: default
     app.kubernetes.io/part-of: "curiefense"
@@ -1318,7 +1319,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.8
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     istio.io/rev: default
     app.kubernetes.io/part-of: "curiefense"
@@ -1428,7 +1429,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.8
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     istio.io/rev: default
     app.kubernetes.io/part-of: "curiefense"
@@ -1531,7 +1532,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.9
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
@@ -1626,7 +1627,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.9
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     istio.io/rev: default
     app.kubernetes.io/part-of: "curiefense"
@@ -1686,7 +1687,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.9
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     istio.io/rev: default
     app.kubernetes.io/part-of: "curiefense"
@@ -1826,7 +1827,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.9
-  namespace: istio-system
+  namespace: "{{ .Release.Namespace }}"
   labels:
     istio.io/rev: default
     app.kubernetes.io/part-of: "curiefense"
@@ -1970,7 +1971,7 @@ webhooks:
   clientConfig:
     service:
       name: istiod
-      namespace: istio-system
+      namespace: "{{ .Release.Namespace }}"
       path: "/inject"
     caBundle: ""
   sideEffects: None

--- a/istio-helm/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -220,7 +220,7 @@ spec:
     {{- if .Values.global.caAddress }}
       value: {{ .Values.global.caAddress }}
     {{- else }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.namespace }}.svc:15012
     {{- end }}
     - name: POD_NAME
       valueFrom:

--- a/istio-helm/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -8,7 +8,7 @@
     # When processing a leaf namespace Istio will search for declarations in that namespace first
     # and if none are found it will search in the root namespace. Any matching declaration found in the root namespace
     # is processed as if it were declared in the leaf namespace.
-    rootNamespace: {{ .Values.meshConfig.rootNamespace | default .Values.global.istioNamespace }}
+    rootNamespace: {{ .Values.meshConfig.rootNamespace | default .Release.Namespace }}
 
     defaultConfig:
       {{- if .Values.global.meshID }}
@@ -26,7 +26,7 @@
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         zipkin:
           # Address of the Zipkin collector
-          address: {{ .Values.global.tracer.zipkin.address | default (print "zipkin." .Values.global.istioNamespace ":9411") }}
+          address: {{ .Values.global.tracer.zipkin.address | default (print "zipkin." .Release.Namespace ":9411") }}
       {{- else if eq .Values.global.proxy.tracer "datadog" }}
         datadog:
           # Address of the Datadog Agent

--- a/istio-helm/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
 data:
 {{/* Scope the values to just top level fields used in the template, to reduce the size. */}}
   values: |-
-{{ pick .Values "global" "istio_cni" "sidecarInjectorWebhook" "revision" | toPrettyJson | indent 4 }}
+{{ set (pick .Values "global" "istio_cni" "sidecarInjectorWebhook" "revision") "namespace" .Release.Namespace | toPrettyJson | indent 4 }}
 
   # To disable injection: use omitSidecarInjectorConfigMap, which disables the webhook patching
   # and istiod webhook functionality.

--- a/istio-helm/charts/istio-control/istio-discovery/values.yaml
+++ b/istio-helm/charts/istio-control/istio-discovery/values.yaml
@@ -207,7 +207,7 @@ meshConfig:
 
 global:
   # Used to locate istiod.
-  istioNamespace: istio-system
+  istioNamespace: UNUSED3
   # enable pod disruption budget for the control plane, which is used to
   # ensure Istio control plane components are gradually upgraded or recovered.
   defaultPodDisruptionBudget:
@@ -435,7 +435,7 @@ global:
   #     endpoints:
   #     - fromRegistry: reg1
   #     gateways:
-  #     - registryServiceName: istio-ingressgateway.istio-system.svc.cluster.local
+  #     - registryServiceName: "istio-ingressgateway.istio-system.svc.cluster.local"
   #       port: 443
   #
   meshNetworks: {}

--- a/istio-helm/deploy.sh
+++ b/istio-helm/deploy.sh
@@ -9,6 +9,7 @@ if [ -z "$DOCKER_TAG" ]; then
     DOCKER_TAG="$GITTAG-$DOCKER_DIR_HASH"
 fi
 
+NAMESPACE=${NAMESPACE:-istio-system}
 PARAMS=()
 
 if [ -n "$NOPULL" ]; then
@@ -19,18 +20,18 @@ if [ -n "$JWT_WORKAROUND" ]; then
     PARAMS+=("-f" "charts/first-party-jwt.yaml")
 fi
 # Install the Istio base chart which contains cluster-wide resources used by the Istio control plane
-helm upgrade istio-base charts/base -n istio-system --install \
+helm upgrade istio-base charts/base -n "$NAMESPACE" --install \
     --wait --timeout 600s --create-namespace
 
 # Install the Istio discovery chart which deploys the istiod service
 helm upgrade istiod charts/istio-control/istio-discovery \
     "${PARAMS[@]}" \
     --wait --timeout 600s \
-    -n istio-system --install
+    -n "$NAMESPACE" --install
 
 # shellcheck disable=SC2086
 if ! helm upgrade istio-ingress charts/gateways/istio-ingress \
-    --install --namespace istio-system --reuse-values --debug \
+    --install --namespace "$NAMESPACE" --reuse-values --debug \
     -f charts/enable-waf-ingress.yaml \
     -f charts/first-party-jwt.yaml \
     "${PARAMS[@]}" \
@@ -39,6 +40,6 @@ if ! helm upgrade istio-ingress charts/gateways/istio-ingress \
     --set "global.proxy.curiesync_image=curiefense/curiesync:$DOCKER_TAG" "$@"
 then
     echo "istio deployment failure... "
-    kubectl --namespace istio-system describe pods
+    kubectl --namespace "$NAMESPACE" describe pods
     # TODO(flaper87): Print logs from failed PODs
 fi


### PR DESCRIPTION
This PR replaces references to the `istio-system` (except in istio-egress & istiod-remote, which we don't use) to make it possible to deploy to another namespace.

To deploy:
```
NAMESPACE=istio-new-namespace DOCKER_TAG=main ./deploy.sh
```

Of course, secrets that allow access to the storage bucket (S3, GS, minio) must be defined in that namespace beforehand.

I'll update docs.curiefense.io when this is merged.

Tested on a GKE cluster.

Signed-off-by: Xavier <xavier@reblaze.com>