### PR TITLE
Make names of folders that store configs more specific

### DIFF
--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-statefulset.yaml
@@ -33,7 +33,7 @@ spec:
             - name: "IF_NO_CONFIG_INIT_FROM"
               value: "/bootstrap/confdb-initial-data/"
           volumeMounts:
-          - mountPath: /config
+          - mountPath: /cf-persistent-config
             name: persistent-confdb
           command: ["/usr/bin/dumb-init", "/bin/bash", "/bootstrap/bootstrap_config.sh"]
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
@@ -122,7 +122,7 @@ spec:
         - mountPath: /run/secrets/miniocfg
           name: miniocfg
 {{- end }}
-        - mountPath: /config
+        - mountPath: /cf-persistent-config
           name: persistent-confdb
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         resources:

--- a/istio-helm/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -146,7 +146,7 @@ spec:
           - mountPath: /run/secrets/miniocfg
             name: miniocfg
 {{- end }}
-          - mountPath: /config
+          - mountPath: /cf-config
             name: curiefense-config
 {{- end }}
       containers:
@@ -197,7 +197,7 @@ spec:
           - mountPath: /run/secrets/miniocfg
             name: miniocfg
 {{- end }}
-          - mountPath: /config
+          - mountPath: /cf-config
             name: curiefense-config
 {{- end }}
         - name: istio-proxy
@@ -371,7 +371,7 @@ spec:
           volumeMounts:
           {{- if $gateway.waf.enabled }}
           - name: curiefense-config
-            mountPath: /config
+            mountPath: /cf-config
           {{- end }}
           - name: istio-envoy
             mountPath: /etc/istio/proxy


### PR DESCRIPTION
This commits changes folder names (see https://github.com/curiefense/curiefense/pull/716):
* persistent data for confserver will now be stored in `/cf-persistent-config`
* generated configs for the envoy rust module will be in `/cf-config`