### PR TITLE
Support for new ingress API and setting nodeSelector

### DIFF
--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-statefulset.yaml
@@ -33,7 +33,7 @@ spec:
             - name: "IF_NO_CONFIG_INIT_FROM"
               value: "/bootstrap/confdb-initial-data/"
           volumeMounts:
-          - mountPath: /config
+          - mountPath: /cf-persistent-config
             name: persistent-confdb
           command: ["/usr/bin/dumb-init", "/bin/bash", "/bootstrap/bootstrap_config.sh"]
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
@@ -122,7 +122,7 @@ spec:
         - mountPath: /run/secrets/miniocfg
           name: miniocfg
 {{- end }}
-        - mountPath: /config
+        - mountPath: /cf-persistent-config
           name: persistent-confdb
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         resources:

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/confserver-statefulset.yaml
@@ -33,7 +33,7 @@ spec:
             - name: "IF_NO_CONFIG_INIT_FROM"
               value: "/bootstrap/confdb-initial-data/"
           volumeMounts:
-          - mountPath: /cf-persistent-config
+          - mountPath: /config
             name: persistent-confdb
           command: ["/usr/bin/dumb-init", "/bin/bash", "/bootstrap/bootstrap_config.sh"]
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
@@ -122,7 +122,7 @@ spec:
         - mountPath: /run/secrets/miniocfg
           name: miniocfg
 {{- end }}
-        - mountPath: /cf-persistent-config
+        - mountPath: /config
           name: persistent-confdb
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         resources:
@@ -173,6 +173,10 @@ spec:
 {{- if .Values.global.tolerations }}
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
 {{- end }}
   volumeClaimTemplates:
   - metadata:

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/curietasker-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/curietasker-deployment.yaml
@@ -41,3 +41,7 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+{{- end }}

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/minio-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/minio-statefulset.yaml
@@ -82,6 +82,10 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+{{- end }}
   volumeClaimTemplates:
   - metadata:
       name: persistent-minio

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-deployment.yaml
@@ -50,3 +50,7 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+{{- end }}

--- a/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-ingress.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-admin/templates/uiserver-ingress.yaml
@@ -1,4 +1,36 @@
 {{- if .Values.global.settings.uiserver_domain }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: uiserver
+  labels:
+    app.kubernetes.io/name: uiserver
+    app.kubernetes.io/part-of: "curiefense"
+  annotations:
+    {{- range $key, $value := .Values.global.settings.uiserver_ingress_annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.global.settings.uiserver_ingress_class_name | default "" }}
+{{- if .Values.global.settings.uiserver_enable_tls }}
+  tls:
+  - hosts:
+    - {{ .Values.global.settings.uiserver_domain }}
+    secretName: {{ .Values.global.settings.uiserver_domain  | replace "." "-" }}-tls
+{{- end }}
+  rules:
+  - host: {{ .Values.global.settings.uiserver_domain }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: uiserver
+            port:
+              number: 80
+{{- else }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -17,7 +49,7 @@ spec:
   - hosts:
     - {{ .Values.global.settings.uiserver_domain }}
     secretName: {{ .Values.global.settings.uiserver_domain  | replace "." "-" }}-tls
-{{- end}}
+{{- end }}
   rules:
   - host: {{ .Values.global.settings.uiserver_domain }}
     http:
@@ -26,4 +58,5 @@ spec:
         backend:
           serviceName: uiserver
           servicePort: http
+{{- end }}
 {{- end }}

--- a/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/grafana-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/grafana-statefulset.yaml
@@ -56,6 +56,10 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+{{- end }}
   volumeClaimTemplates:
   - metadata:
       name: persistent-grafana

--- a/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/prometheus-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-dashboard/templates/prometheus-statefulset.yaml
@@ -54,6 +54,10 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+{{- end }}
   volumeClaimTemplates:
   - metadata:
       name: persistent-prometheus

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/elasticsearch-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/elasticsearch-statefulset.yaml
@@ -64,6 +64,10 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+{{- end }}
   volumeClaimTemplates:
   - metadata:
       name: persistent-elasticsearch

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/fluentd-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/fluentd-deployment.yaml
@@ -65,5 +65,9 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/kibana-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/kibana-deployment.yaml
@@ -52,4 +52,8 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+{{- end }}
 {{- end }}

--- a/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-log/templates/logstash-deployment.yaml
@@ -73,5 +73,9 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-deployment.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-proxy/templates/curielogger-deployment.yaml
@@ -123,6 +123,10 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+{{- end }}
       volumes:
 {{- if $curielogger.extraVolumes }}
 {{ toYaml $curielogger.extraVolumes | indent 6 }}

--- a/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-statefulset.yaml
@@ -52,6 +52,10 @@ spec:
       tolerations:
 {{ toYaml .Values.global.tolerations | indent 8 }}
 {{- end }}
+{{- if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+{{- end }}
   volumeClaimTemplates:
   - metadata:
       name: persistent-redis


### PR DESCRIPTION
Since kubernetes v1.22 extensions/v1beta1 and networking.k8s.io/v1beta1 API versions of Ingress is no longer served.
Additionally I needed to restrict deployment to specific nodes so I have added nodeSelector support.