### PR TITLE
Using custom redis in Helm

### DIFF
--- a/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-service-headless.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-service-headless.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.enable.redis }}
 ---
 # a headless service is required for StatefulSets
 apiVersion: v1
@@ -16,3 +17,4 @@ spec:
   clusterIP: None
   selector:
     app.kubernetes.io/name: redis
+{{- end }}

--- a/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-service.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.enable.redis }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
     targetPort: 6379
   selector:
     app.kubernetes.io/name: redis
+{{- end }}

--- a/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-statefulset.yaml
+++ b/curiefense-helm/curiefense/charts/curiefense-proxy/templates/redis-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.enable.redis }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -62,3 +63,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.global.storage.redis_storage_size }}
+  {{- end }}

--- a/curiefense-helm/curiefense/values.yaml
+++ b/curiefense-helm/curiefense/values.yaml
@@ -81,3 +81,4 @@ global:
     logstash: true
     filebeat: true
     minio: true
+    redis: true

--- a/istio-helm/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -333,6 +333,12 @@ spec:
             value: "{{ $.Values.global.proxy.redis_host }}"
           - name: REDIS_PORT
             value: "{{ $.Values.global.proxy.redis_port }}"
+          {{- if $.Values.global.proxy.redis_password }}
+          - name: REDIS_PASSWORD
+            value: "{{ $.Values.global.proxy.redis_password }}"
+          {{- end }}
+          - name: REDIS_DB
+            value: "{{ $.Values.global.proxy.redis_db }}"
           {{- end }}
           {{- range $key, $val := $gateway.env }}
           - name: {{ $key }}

--- a/istio-helm/charts/gateways/istio-ingress/values.yaml
+++ b/istio-helm/charts/gateways/istio-ingress/values.yaml
@@ -235,6 +235,8 @@ global:
     # typically "redis.$curiefense_namespace", can be changed to use an external redis instance
     redis_host: "redis.curiefense"
     redis_port: 6379
+    redis_password: ""
+    redis_db: "0"
     # valid values: true  = pull initial config from bucket then start gateway
     #               false = start gateway with a bootstrap config without waiting for the config from the bucket
     initial_curieconf_pull: true


### PR DESCRIPTION
1. It is allowed to specify the redis service enabling status in helm.
2. Optimize the custom redis configuration in istio ingress gateway.